### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ within the project.
 2. Click on **"This Firefox"**
 3. Click on: **"Load Temporary Add-on…"**
 4. Navigate to the `stacks-wallet-web` project directory
-5. Select the `manifest.json` file.
+5. Select the `manifest.json` file from the `stacks-wallet-web/dist` directory.
 
 ### Adding a Changeset
 


### PR DESCRIPTION
> Try out this version of the Hiro Wallet - download [extension builds](https://github.com/blockstack/ux/actions/runs/1083695220).<!-- Sticky Header Marker -->

Updated the Firefox temporary web extension install instructions to clarify that the `mainfest.json` file is in the `stacks-wallet-web/dist` directory.

See Issue: https://github.com/blockstack/stacks-wallet-web/issues/1511

<!--
PR reminders:
  - Link issues to PR
  - Update UserX board
  - Use checkmarks for progress
  - Link PRs in other issues

Tips for good PR etiquette https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/
-->

cc/ @aulneau @kyranjamie @fbwoolf
